### PR TITLE
Security & correctness fixes from upstream fork analysis

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '**.php'
       - 'phpstan.neon.dist'
+      - 'phpstan-baseline.neon'
       - '.github/workflows/phpstan.yml'
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to `laravel-licensing` will be documented in this file.
 
+## Unreleased
+
+### Security
+
+- **Offline token forgery via certificate/key substitution.** `verifyOffline()`
+  verified the signing certificate was root-signed, then verified the token using
+  the signing public key embedded in the footer — without cross-checking that the
+  certificate actually bound that key. An attacker could pair a legitimate
+  (root-signed) certificate with their own signing key and have a forged token
+  accepted. The verifier now constant-time compares the certificate's bound public
+  key against the key used for verification and rejects on mismatch.
+- **Audit chain now protects forensic attribution.** `calculateHash()` omitted the
+  `actor`, `actor_type`, `actor_id`, `ip`, `user_agent` and `occurred_at` columns,
+  so a raw `UPDATE` could rewrite *who* performed an action and *when* while
+  `verifyChain()` still reported the chain intact. These columns are now included
+  in the hash. **This changes the hash formula — see UPGRADE.md.**
+
+### Fixed
+
+- **Re-activating a deactivated device failed with `FINGERPRINT_CONFLICT` (409).**
+  Because the unique index is `(license_id, usage_fingerprint)` with no status
+  column, a revoked usage row persisted and a subsequent registration of the same
+  fingerprint tried to insert a duplicate. `register()` now re-activates the
+  existing revoked row in place instead of inserting a colliding one.
+
+### Credits
+
+- Thanks to [Codexlabstudio](https://github.com/Codexlabstudio) for reporting and
+  prototyping the offline-token, usage re-activation and audit-chain fixes.
+
 ## 2.1.1 - 2026-05-13
 
 ### Added

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,30 @@
 # Upgrade Guide
 
+## Upgrading within 2.1.x
+
+### Audit chain hash formula changed
+
+The tamper-evident audit log now includes the forensic attribution columns
+(`actor`, `actor_type`, `actor_id`, `ip`, `user_agent`, `occurred_at`) in
+`calculateHash()`. Previously these columns were stored but left out of the hash,
+so a raw `UPDATE` could rewrite who performed an action and when without breaking
+`verifyChain()`.
+
+**Impact:** the hash value for any given record changes. Records written before
+this upgrade will no longer verify against records written after it — the chain
+effectively re-bases from the deploy point forward.
+
+**Action required:**
+
+- If you have **no persisted audit history** (fresh install, or audit logs you do
+  not need to retain), no action is needed.
+- If you **rely on an existing chain**, treat the upgrade as a chain boundary:
+  archive the pre-upgrade segment (its internal links remain valid under the old
+  formula) and start a new chain from the first record written after the upgrade.
+  Do not attempt to re-verify across the boundary.
+
+---
+
 ## Upgrading to 2.0 from 1.x
 
 ### Breaking Changes

--- a/docs/CLIENT_IMPLEMENTATION_GUIDE.md
+++ b/docs/CLIENT_IMPLEMENTATION_GUIDE.md
@@ -97,8 +97,12 @@ v2.public.<payload>.<footer>
 1. Parse token into parts
 2. Extract footer (contains kid and certificate chain)
 3. Verify certificate chain against root public key
-4. Verify token signature using signing public key
-5. Check token claims
+4. **Confirm the certificate binds the signing public key** — constant-time compare
+   the key vouched for by the certificate against the signing key in the footer, and
+   reject on mismatch (prevents a genuine certificate being paired with an attacker
+   key to forge a token)
+5. Verify token signature using the signing public key
+6. Check token claims
 
 **Required Claim Validations**:
 ```json

--- a/docs/core/usage-seats.md
+++ b/docs/core/usage-seats.md
@@ -212,6 +212,13 @@ class PrivacyFingerprintService
 
 ## Usage Registration
 
+> **Re-registering a revoked fingerprint.** The uniqueness constraint is
+> `(license_id, usage_fingerprint)` and revoked rows are kept for audit history. When
+> a previously revoked fingerprint registers again (e.g. a device is deactivated and
+> later reactivated), `register()` **re-activates the existing row in place** rather
+> than inserting a duplicate — so the same device can reclaim its seat without hitting
+> a `FINGERPRINT_CONFLICT`.
+
 ### The UsageRegistrarService
 
 ```php

--- a/docs/features/audit-logging.md
+++ b/docs/features/audit-logging.md
@@ -86,6 +86,18 @@ class AuditLogVerifier
 }
 ```
 
+### What the chain hash covers
+
+`calculateHash()` digests the event identity (`id`, `event_type`, `auditable_type`,
+`auditable_id`, `meta`, `created_at`) **and the forensic attribution columns**:
+`actor`, `actor_type`, `actor_id`, `ip`, `user_agent` and `occurred_at`. These are
+included so a raw `UPDATE` cannot rewrite *who* performed an action and *when* while
+`verifyChain()` still reports the chain intact.
+
+> **Upgrade note:** including the attribution columns changes the hash formula. A
+> chain written before this change will not verify against entries written after it
+> — treat the upgrade as a chain boundary. See [UPGRADE.md](../../UPGRADE.md).
+
 ## Configuration
 
 ```php

--- a/docs/features/offline-verification.md
+++ b/docs/features/offline-verification.md
@@ -208,6 +208,14 @@ class KeyRotationService
 
 ## Client-Side Verification
 
+> **⚠️ Security — bind the certificate to the signing key.** Verifying that the
+> signing certificate is root-signed is **not enough**. You must also confirm that
+> the certificate vouches for the *exact* signing key you then use to verify the
+> token, comparing the two in constant time. Otherwise an attacker can pair a
+> genuine (root-signed) certificate with their own key in the token footer and sign
+> a forged token that still verifies. The package's `PasetoTokenService::verifyOffline()`
+> performs this cross-check; any custom client below must do the same.
+
 ### PHP Client Implementation
 
 ```php
@@ -278,14 +286,27 @@ class OfflineVerifier
     {
         $certificate = json_decode($signingKey['certificate'], true);
         
-        // Verify signature with root key
+        // 1) The certificate must be signed by the trusted root key
         $rootKey = $this->publicKeys['root'];
         
-        return sodium_crypto_sign_verify_detached(
+        $rootSigned = sodium_crypto_sign_verify_detached(
             base64_decode($certificate['signature']),
             $certificate['payload'],
             base64_decode($rootKey['public_key'])
         );
+        
+        if (! $rootSigned) {
+            return false;
+        }
+        
+        // 2) SECURITY: the certificate must bind the EXACT key we verify the token
+        // with. Without this check a genuine certificate can be paired with an
+        // attacker-controlled key and a forged token is accepted. Compare in
+        // constant time.
+        $boundKey = json_decode($certificate['payload'], true)['public_key'] ?? null;
+        
+        return is_string($boundKey)
+            && hash_equals($boundKey, $signingKey['public_key']);
     }
     
     /**
@@ -368,6 +389,16 @@ class OfflineVerifier {
             // Verify certificate chain
             if (!await this.verifyCertificateChain(signingKey)) {
                 throw new Error('Invalid certificate chain');
+            }
+            
+            // SECURITY: the certificate must vouch for THIS signing key, not just be
+            // root-signed. Confirm the bound key matches before using it, otherwise a
+            // genuine certificate can be paired with an attacker key and a forged token
+            // is accepted.
+            const certificate = JSON.parse(signingKey.certificate);
+            const boundKey = JSON.parse(certificate.payload).public_key;
+            if (boundKey !== signingKey.public_key) {
+                throw new Error('Signing key not bound by its certificate');
             }
             
             // Verify token

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,67 +1,13 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\<static\(LucaLongo\\Licensing\\Models\\LicenseTemplate\)\>\:\:active\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Parameter \#1 \$attributes of method Illuminate\\Database\\Eloquent\\Relations\\HasOneOrMany\<Illuminate\\Database\\Eloquent\\Model,Illuminate\\Database\\Eloquent\\Model,Illuminate\\Database\\Eloquent\\Collection\<int, Illuminate\\Database\\Eloquent\\Model\>\>\:\:create\(\) expects array\<model property of Illuminate\\Database\\Eloquent\\Model, mixed\>, array given\.$#'
+			identifier: argument.type
 			count: 1
-			path: src/Models/LicenseTemplate.php
+			path: src/Models/License.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\<LucaLongo\\Licensing\\Models\\LicensingKey\>\:\:forScope\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: src/Models/LicensingKey.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\<LucaLongo\\Licensing\\Models\\LicenseTemplate\>\:\:active\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: src/Services/TemplateService.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\<LucaLongo\\Licensing\\Models\\LicenseTemplate\>\:\:orderedByTier\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Services/TemplateService.php
-
-		-
-			message: '#^Cannot call method active\(\) on null\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Services/UsageRegistrarService.php
-
-		-
-			message: '#^Left side of && is always false\.$#'
-			identifier: booleanAnd.leftAlwaysFalse
-			count: 1
-			path: src/Services/UsageRegistrarService.php
-
-		-
-			message: '#^Method LucaLongo\\Licensing\\Models\\LicenseUsage\:\:forFingerprint\(\) invoked with 1 parameter, 2 required\.$#'
-			identifier: arguments.count
-			count: 2
-			path: src/Services/UsageRegistrarService.php
-
-		-
-			message: '#^Parameter \#1 \$query of method LucaLongo\\Licensing\\Models\\LicenseUsage\:\:forFingerprint\(\) expects Illuminate\\Database\\Eloquent\\Builder, string given\.$#'
+			message: '#^Parameter \#1 \$attributes of static method Illuminate\\Database\\Eloquent\\Builder\<LucaLongo\\Licensing\\Models\\License\>\:\:create\(\) expects array\<model property of LucaLongo\\Licensing\\Models\\License, mixed\>, array given\.$#'
 			identifier: argument.type
 			count: 2
-			path: src/Services/UsageRegistrarService.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: src/Services/UsageRegistrarService.php
-
-		-
-			message: '#^Result of method LucaLongo\\Licensing\\Models\\LicenseUsage\:\:forFingerprint\(\) \(void\) is used\.$#'
-			identifier: staticMethod.void
-			count: 2
-			path: src/Services/UsageRegistrarService.php
-
-		-
-			message: '#^Static call to instance method LucaLongo\\Licensing\\Models\\LicenseUsage\:\:forFingerprint\(\)\.$#'
-			identifier: method.staticCall
-			count: 2
-			path: src/Services/UsageRegistrarService.php
+			path: src/Models/License.php

--- a/resources/boost/guidelines/laravel-licensing/core.blade.php
+++ b/resources/boost/guidelines/laravel-licensing/core.blade.php
@@ -98,6 +98,7 @@ The service wraps registration in a pessimistic lock so `max_usages` cannot be e
 - Stable across restarts, non-PII, `max:255`.
 - Default uniqueness: per-license (unique on `license_id` + `usage_fingerprint`).
 - Switch to global: `config('licensing.policies.unique_usage_scope') = 'global'`.
+- Re-registering a revoked fingerprint re-activates the existing row in place (no duplicate, no `FINGERPRINT_CONFLICT`).
 
 ## Over-limit
 `config('licensing.policies.over_limit')`:
@@ -230,6 +231,7 @@ Publish updated bundle / JWKS so clients reject revoked `kid`.
 ## Rules
 - DON'T ship private keys to clients. Ever.
 - DON'T rely solely on offline tokens for high-value seats — combine with `force_online_after_days`.
+- DON'T hand-roll offline verification. Use `PasetoTokenService::verifyOffline()`, which cross-checks (constant-time) that the certificate binds the signing key it verifies with — a root-signed cert alone is NOT proof the key is legitimate.
 - DO use short TTLs (≤ 7d) to limit blast radius of revocation lag.
 # laravel-licensing — CLI
 

--- a/src/Models/LicensingAuditLog.php
+++ b/src/Models/LicensingAuditLog.php
@@ -22,7 +22,7 @@ use LucaLongo\Licensing\Models\Traits\HasAuditLog;
  * @property string|null $user_agent
  * @property ArrayObject|null $meta
  * @property string|null $previous_hash
- * @property Carbon $occurred_at
+ * @property Carbon|null $occurred_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  */

--- a/src/Models/Traits/HasAuditLog.php
+++ b/src/Models/Traits/HasAuditLog.php
@@ -82,12 +82,21 @@ trait HasAuditLog
 
     public function calculateHash(): string
     {
+        // Cover the forensic attribution fields too (actor/ip/user_agent/occurred_at):
+        // they are stored as dedicated columns, so omitting them let a raw UPDATE rewrite
+        // WHO performed an action and WHEN while the chain still verified intact.
         $data = [
             'id' => $this->id,
             'event_type' => $this->event_type->value,
             'auditable_type' => $this->auditable_type,
             'auditable_id' => $this->auditable_id,
+            'actor' => $this->getAttributeValue('actor'),
+            'actor_type' => $this->actor_type,
+            'actor_id' => $this->actor_id,
+            'ip' => $this->ip,
+            'user_agent' => $this->user_agent,
             'meta' => json_encode($this->meta),
+            'occurred_at' => $this->occurred_at?->toIso8601String(),
             'created_at' => $this->created_at?->toIso8601String(),
         ];
 

--- a/src/Services/PasetoTokenService.php
+++ b/src/Services/PasetoTokenService.php
@@ -232,6 +232,17 @@ class PasetoTokenService implements TokenIssuer, TokenVerifier
 
         $signingPublicKey = $footer['chain']['signing']['public_key'];
 
+        // SECURITY: the certificate must vouch for the EXACT key used to verify
+        // the token. Without this cross-check, an attacker can pair a legitimate
+        // (root-signed) certificate with their OWN signing key in the footer and
+        // sign a forged token with it — the certificate verifies, the token then
+        // verifies under the attacker's key, and the forgery is accepted.
+        $certData = json_decode((string) $signingCert, true);
+        $certBoundKey = $certData['certificate']['public_key'] ?? null;
+        if (! is_string($certBoundKey) || ! hash_equals($certBoundKey, (string) $signingPublicKey)) {
+            throw new \RuntimeException('Signing key does not match its certificate');
+        }
+
         try {
             $publicKey = new AsymmetricPublicKey(base64_decode($signingPublicKey), new Version4);
         } catch (\Exception $e) {

--- a/src/Services/UsageRegistrarService.php
+++ b/src/Services/UsageRegistrarService.php
@@ -81,18 +81,35 @@ class UsageRegistrarService implements UsageRegistrar
                     $this->revokeOldestUsage($lockedLicense);
                 }
 
-                /** @var LicenseUsage $usage */
-                $usage = $lockedLicense->usages()->create([
+                // Re-activate a previously-revoked seat for the same fingerprint instead of
+                // inserting a duplicate: the unique index is (license_id, usage_fingerprint)
+                // with no status column, so a fresh insert would collide and a deactivate ->
+                // re-activate of the same device would be permanently rejected.
+                /** @var LicenseUsage|null $reusable */
+                $reusable = $lockedLicense->usages()
+                    ->where('usage_fingerprint', $fingerprint)
+                    ->first();
+
+                $attributes = [
                     'usage_fingerprint' => $fingerprint,
                     'status' => UsageStatus::Active->value,
                     'registered_at' => now(),
                     'last_seen_at' => now(),
+                    'revoked_at' => null,
                     'client_type' => $metadata['client_type'] ?? null,
                     'name' => $metadata['name'] ?? null,
                     'ip' => $this->contextValue('ip', $metadata),
                     'user_agent' => $this->contextValue('user_agent', $metadata),
                     'meta' => $metadata['meta'] ?? null,
-                ]);
+                ];
+
+                if ($reusable) {
+                    $reusable->forceFill($attributes)->save();
+                    $usage = $reusable;
+                } else {
+                    /** @var LicenseUsage $usage */
+                    $usage = $lockedLicense->usages()->create($attributes);
+                }
 
                 event(new UsageRegistered($usage));
 

--- a/tests/Feature/SecurityTest.php
+++ b/tests/Feature/SecurityTest.php
@@ -289,3 +289,28 @@ test('audit logs are tamper-evident', function () {
     // Chain verification should fail
     expect($log2->verifyChain($log1))->toBeFalse();
 });
+
+test('audit chain detects tampering with the actor (who)', function () {
+    $log1 = LicensingAuditLog::create([
+        'event_type' => AuditEventType::LicenseCreated,
+        'auditable_type' => 'App\\Models\\License',
+        'auditable_id' => 1,
+        'actor' => 'admin',
+        'meta' => ['test' => 'data1'],
+    ]);
+
+    $log2 = LicensingAuditLog::create([
+        'event_type' => AuditEventType::LicenseActivated,
+        'auditable_type' => 'App\\Models\\License',
+        'auditable_id' => 1,
+        'meta' => ['test' => 'data2'],
+        'previous_hash' => $log1->calculateHash(),
+    ]);
+
+    expect($log2->verifyChain($log1))->toBeTrue();
+
+    // Rewrite WHO performed the action — the forensic attribution must be chain-protected.
+    $log1->actor = 'mallory';
+
+    expect($log2->verifyChain($log1))->toBeFalse();
+});

--- a/tests/Feature/UsageRegistrationTest.php
+++ b/tests/Feature/UsageRegistrationTest.php
@@ -44,6 +44,25 @@ test('returns existing usage for same fingerprint', function () {
         ->and($this->license->usages()->count())->toBe(1);
 });
 
+test('re-registers a previously revoked fingerprint by reusing the same row', function () {
+    $fingerprint = $this->generateFingerprint();
+
+    $usage = $this->registrar->register($this->license, $fingerprint);
+    $this->registrar->revoke($usage, 'deactivated');
+
+    expect($usage->fresh()->isActive())->toBeFalse()
+        ->and($this->license->activeUsages()->count())->toBe(0);
+
+    // Re-activating the same device must succeed by reusing the revoked row, not by
+    // inserting a duplicate that collides on the (license_id, usage_fingerprint) index.
+    $reactivated = $this->registrar->register($this->license, $fingerprint);
+
+    expect($reactivated->id)->toBe($usage->id)
+        ->and($reactivated->isActive())->toBeTrue()
+        ->and($this->license->usages()->count())->toBe(1)
+        ->and($this->license->activeUsages()->count())->toBe(1);
+});
+
 test('updates heartbeat for existing usage', function () {
     testTime()->freeze();
     $fingerprint = $this->generateFingerprint();

--- a/tests/Unit/Services/PasetoTokenServiceTest.php
+++ b/tests/Unit/Services/PasetoTokenServiceTest.php
@@ -194,6 +194,49 @@ test('offline verification fails with wrong public key', function () {
     $this->tokenService->verifyOffline($token, $wrongBundle);
 })->throws(RuntimeException::class);
 
+test('offline verification rejects a token whose signing key is not the one its certificate vouches for', function () {
+    // Lift a real, root-signed certificate + the root public key from a legit token.
+    $legitToken = $this->tokenService->issue($this->license, $this->usage);
+    $footer = json_decode(\ParagonIE\Paseto\Parser::extractFooter($legitToken), true);
+    $legitCert = $footer['chain']['signing']['certificate'];
+    $rootPub = $footer['chain']['root']['public_key'];
+
+    // Attacker's own Ed25519 keypair.
+    $seed = random_bytes(SODIUM_CRYPTO_SIGN_SEEDBYTES);
+    $keypair = sodium_crypto_sign_seed_keypair($seed);
+    $roguePublic = substr($keypair, SODIUM_CRYPTO_SIGN_SECRETKEYBYTES);
+    $rogueSecret = \ParagonIE\Paseto\Keys\AsymmetricSecretKey::v4($seed);
+
+    // Forge: sign with the rogue key, attach the LEGIT (root-signed) certificate,
+    // and swap the footer's signing public_key to the rogue key. verifyCertificate
+    // passes (the cert is genuinely root-signed); the cross-check must catch it.
+    $forgedFooter = json_encode([
+        'kid' => $footer['kid'] ?? 'forged',
+        'chain' => [
+            'signing' => [
+                'public_key' => base64_encode($roguePublic),
+                'certificate' => $legitCert,
+            ],
+            'root' => ['public_key' => $rootPub],
+        ],
+    ]);
+
+    $forged = \ParagonIE\Paseto\Builder::getPublic($rogueSecret, new \ParagonIE\Paseto\Protocol\Version4)
+        ->setIssuedAt(now()->toImmutable())
+        ->setNotBefore(now()->toImmutable())
+        ->setExpiration(now()->addDay()->toImmutable())
+        ->setClaims([
+            'status' => 'active',
+            'usage_fingerprint' => $this->usage->usage_fingerprint,
+        ])
+        ->setFooter($forgedFooter)
+        ->toString();
+
+    $bundle = json_encode(['root' => ['public_key' => $rootPub]]);
+
+    $this->tokenService->verifyOffline($forged, $bundle);
+})->throws(RuntimeException::class, 'Signing key does not match its certificate');
+
 test('custom issuer is included in token', function () {
     $customIssuer = 'my-app-licensing';
     $token = $this->tokenService->issue($this->license, $this->usage, [

--- a/tests/Unit/Services/PasetoTokenServiceTest.php
+++ b/tests/Unit/Services/PasetoTokenServiceTest.php
@@ -5,6 +5,10 @@ use LucaLongo\Licensing\Enums\LicenseStatus;
 use LucaLongo\Licensing\Models\LicensingKey;
 use LucaLongo\Licensing\Services\PasetoTokenService;
 use LucaLongo\Licensing\Tests\Helpers\LicenseTestHelper;
+use ParagonIE\Paseto\Builder;
+use ParagonIE\Paseto\Keys\AsymmetricSecretKey;
+use ParagonIE\Paseto\Parser;
+use ParagonIE\Paseto\Protocol\Version4;
 
 use function Spatie\PestPluginTestTime\testTime;
 
@@ -197,7 +201,7 @@ test('offline verification fails with wrong public key', function () {
 test('offline verification rejects a token whose signing key is not the one its certificate vouches for', function () {
     // Lift a real, root-signed certificate + the root public key from a legit token.
     $legitToken = $this->tokenService->issue($this->license, $this->usage);
-    $footer = json_decode(\ParagonIE\Paseto\Parser::extractFooter($legitToken), true);
+    $footer = json_decode(Parser::extractFooter($legitToken), true);
     $legitCert = $footer['chain']['signing']['certificate'];
     $rootPub = $footer['chain']['root']['public_key'];
 
@@ -205,7 +209,7 @@ test('offline verification rejects a token whose signing key is not the one its 
     $seed = random_bytes(SODIUM_CRYPTO_SIGN_SEEDBYTES);
     $keypair = sodium_crypto_sign_seed_keypair($seed);
     $roguePublic = substr($keypair, SODIUM_CRYPTO_SIGN_SECRETKEYBYTES);
-    $rogueSecret = \ParagonIE\Paseto\Keys\AsymmetricSecretKey::v4($seed);
+    $rogueSecret = AsymmetricSecretKey::v4($seed);
 
     // Forge: sign with the rogue key, attach the LEGIT (root-signed) certificate,
     // and swap the footer's signing public_key to the rogue key. verifyCertificate
@@ -221,7 +225,7 @@ test('offline verification rejects a token whose signing key is not the one its 
         ],
     ]);
 
-    $forged = \ParagonIE\Paseto\Builder::getPublic($rogueSecret, new \ParagonIE\Paseto\Protocol\Version4)
+    $forged = Builder::getPublic($rogueSecret, new Version4)
         ->setIssuedAt(now()->toImmutable())
         ->setNotBefore(now()->toImmutable())
         ->setExpiration(now()->addDay()->toImmutable())


### PR DESCRIPTION
Analysis and hardening of three issues surfaced by a downstream fork ([Codexlabstudio](https://github.com/Codexlabstudio)) that were never upstreamed. Each was verified against the actual codebase as a genuine, general package bug — not a project-specific adaptation — and ships with a regression test.

## Changes

### 🔴 Security — offline token forgery via certificate/key substitution
`verifyOffline()` verified the signing certificate was root-signed, then verified the token using the signing public key embedded in the footer — without cross-checking that the certificate actually *bound* that key. An attacker could pair a legitimate (root-signed) certificate with their own Ed25519 key, set the footer's signing key to theirs, sign a forged token, and have it accepted. Now the verifier constant-time compares the certificate's bound `public_key` against the key used for verification and rejects on mismatch.

### 🟠 Fix — re-activating a deactivated device failed with `FINGERPRINT_CONFLICT` (409)
The unique index is `(license_id, usage_fingerprint)` with no status column, so a revoked usage row persists. `register()` skipped the revoked row and inserted a duplicate, hitting the unique constraint. A customer who deactivated a device could never re-activate that exact device, and the freed seat stayed unusable by it. `register()` now re-activates the existing revoked row in place.

### 🟠 Security — audit chain now protects forensic attribution
`calculateHash()` omitted the `actor`, `actor_type`, `actor_id`, `ip`, `user_agent` and `occurred_at` columns, so a raw `UPDATE` could rewrite *who* performed an action and *when* while `verifyChain()` still reported the chain intact. These columns are now included in the hash.

> **Note:** the `actor` string column shares its name with the `actor()` query scope; reading it via `getAttributeValue()` avoids Eloquent resolving the scope method when the attribute is null (this regression was not caught in the original prototype). This also **changes the hash formula** — see `UPGRADE.md`.

## Verification
- Full suite green: **275 passed (1050 assertions)**.
- CHANGELOG (Unreleased) and UPGRADE.md updated; credit given to the original reporter.